### PR TITLE
Add build instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,35 @@ This repository contains a basic project structure for a live streaming applicat
 - **frontend** – Next.js 15 (React 19) application skeleton.
 
 Both projects are empty templates ready for further development.
+
+## Prerequisites
+
+Make sure the following tools are installed before building the project:
+
+- [Node.js](https://nodejs.org/) (LTS version recommended)
+- [.NET 9 SDK](https://dotnet.microsoft.com/download)
+
+## Backend
+
+To run the backend API locally:
+
+```bash
+cd backend
+
+dotnet run
+```
+
+The API will start on `http://localhost:5000` by default.
+
+## Frontend
+
+To start the Next.js development server:
+
+```bash
+cd frontend
+
+npm install
+npm run dev
+```
+
+The app will be available at `http://localhost:3000`.


### PR DESCRIPTION
## Summary
- document tool prerequisites (Node.js and .NET 9 SDK)
- add instructions for running the backend and frontend

## Testing
- `dotnet build` *(fails: command not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684924bdea288329870f731fd5cfc0e7